### PR TITLE
Feat/#23 기존 장학/채용 탭 URL를 인하대 공식 홈페이지에서 제공하는 URL로 변경

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/lib/screens/bottom_navigation/bottom_nav_bar_page.dart
+++ b/lib/screens/bottom_navigation/bottom_nav_bar_page.dart
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the root directory or at
  * http://www.apache.org/licenses/
  * Author: junho Kim
- * Latest Updated Date: 2025-02-25
+ * Latest Updated Date: 2025-02-26
  */
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';

--- a/lib/screens/bottom_navigation/home/home_page.dart
+++ b/lib/screens/bottom_navigation/home/home_page.dart
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the root directory or at
  * http://www.apache.org/licenses/
  * Author: junho Kim
- * Latest Updated Date: 2025-02-25
+ * Latest Updated Date: 2025-02-26
  */
 import 'package:flutter/material.dart';
 import 'package:inha_notice/fonts/font.dart';
@@ -13,7 +13,6 @@ import 'package:inha_notice/screens/bottom_navigation/more/notification_setting/
 import 'package:inha_notice/screens/notice_board/absolute_style_notice_board.dart';
 import 'package:inha_notice/screens/notice_board/relative_style_notice_board.dart';
 import 'package:inha_notice/themes/theme.dart';
-import 'package:inha_notice/widgets/search/search_result_page.dart';
 
 /// **HomePage**
 /// 이 클래스는 홈 페이지를 정의하는 클래스입니다.
@@ -118,7 +117,7 @@ class HomePage extends StatelessWidget {
                   Tab(text: '학사'),
                   Tab(text: '학과'),
                   Tab(text: '장학'),
-                  Tab(text: '채용'),
+                  Tab(text: '모집/채용'),
                   Tab(text: '정석'),
                   Tab(text: '국제처'),
                   Tab(text: 'SW중심대학사업단'),
@@ -135,8 +134,8 @@ class HomePage extends StatelessWidget {
           children: [
             AbsoluteStyleNoticeBoard(noticeType: 'WHOLE'),
             AbsoluteStyleNoticeBoard(noticeType: 'MAJOR'),
-            SearchResultPage(query: '장학', isSearchResultPage: false),
-            SearchResultPage(query: '채용', isSearchResultPage: false),
+            AbsoluteStyleNoticeBoard(noticeType: 'SCHOLARSHIP'),
+            AbsoluteStyleNoticeBoard(noticeType: 'RECRUITMENT'),
             RelativeStyleNoticeBoard(noticeType: 'LIBRARY'),
             AbsoluteStyleNoticeBoard(noticeType: 'INTERNATIONAL'),
             AbsoluteStyleNoticeBoard(noticeType: 'SWUNIV'),

--- a/lib/screens/notice_board/absolute_style_notice_board.dart
+++ b/lib/screens/notice_board/absolute_style_notice_board.dart
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the root directory or at
  * http://www.apache.org/licenses/
  * Author: junho Kim
- * Latest Updated Date: 2025-02-25
+ * Latest Updated Date: 2025-02-26
  */
 import 'package:flutter/material.dart';
 import 'package:inha_notice/constants/page_constants.dart';
@@ -14,7 +14,7 @@ import 'package:inha_notice/screens/bottom_navigation/more/major_setting/major_s
 import 'package:inha_notice/screens/notice_board/base_notice_board.dart';
 import 'package:inha_notice/services/absolute_style_scraper/base_absolute_style_notice_scraper.dart';
 import 'package:inha_notice/services/absolute_style_scraper/major_style_notice_scraper.dart';
-import 'package:inha_notice/services/absolute_style_scraper/whole_notice_scraper.dart';
+import 'package:inha_notice/services/absolute_style_scraper/whole_style_notice_scraper.dart';
 import 'package:inha_notice/themes/theme.dart';
 import 'package:inha_notice/utils/shared_prefs/shared_prefs_manager.dart';
 import 'package:inha_notice/widgets/buttons/rounded_toggle_button.dart';
@@ -30,7 +30,7 @@ import 'package:pull_to_refresh/pull_to_refresh.dart';
 ///
 /// ### 주요 기능:
 /// - noticeType에 따른 공지사항 제공
-/// - 지원하는 noticeType: 학사공지, 학과공지, 국제처 공지, SW중심대학 공지
+/// - 지원하는 공지: 학사, 장학, 모집/채용, 학과, 국제처, SW중심대학사업단
 class AbsoluteStyleNoticeBoard extends BaseNoticeBoard {
   final String noticeType;
 
@@ -78,13 +78,22 @@ class _AbsoluteStyleNoticeBoardState
     }
 
     // 스크래퍼 초기화 진행
-    if (widget.noticeType == 'WHOLE') {
-      noticeScraper = WholeNoticeScraper();
-    } else if (widget.noticeType == 'MAJOR') {
-      noticeScraper = MajorStyleNoticeScraper(majorKey!);
-    } else {
-      noticeScraper = MajorStyleNoticeScraper(widget.noticeType);
+    // 학사, 장학, 모집/채용
+    if (widget.noticeType == 'WHOLE' ||
+        widget.noticeType == 'SCHOLARSHIP' ||
+        widget.noticeType == 'RECRUITMENT') {
+      noticeScraper = WholeStyleNoticeScraper(widget.noticeType);
+      return;
     }
+
+    // 학과
+    if (widget.noticeType == 'MAJOR') {
+      noticeScraper = MajorStyleNoticeScraper(majorKey!);
+      return;
+    }
+
+    // 학과 스타일(국제처, SW중심대학사업단)
+    noticeScraper = MajorStyleNoticeScraper(widget.noticeType);
   }
 
   /// 초기화 순서(순서를 보장해야함): 스크래퍼 초기화 -> 공지사항 불러오기

--- a/lib/services/absolute_style_scraper/major_style_notice_scraper.dart
+++ b/lib/services/absolute_style_scraper/major_style_notice_scraper.dart
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the root directory or at
  * http://www.apache.org/licenses/
  * Author: junho Kim
- * Latest Updated Date: 2025-02-11
+ * Latest Updated Date: 2025-02-26
  */
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:html/parser.dart';
@@ -19,7 +19,7 @@ import 'package:inha_notice/services/absolute_style_scraper/base_absolute_style_
 class MajorStyleNoticeScraper extends BaseAbsoluteStyleNoticeScraper {
   late final String baseUrl;
   late final String queryUrl;
-  late String noticeType;
+  late final String noticeType;
 
   MajorStyleNoticeScraper(this.noticeType) {
     baseUrl = dotenv.get('${noticeType}_URL');

--- a/lib/services/absolute_style_scraper/whole_style_notice_scraper.dart
+++ b/lib/services/absolute_style_scraper/whole_style_notice_scraper.dart
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the root directory or at
  * http://www.apache.org/licenses/
  * Author: junho Kim
- * Latest Updated Date: 2025-02-11
+ * Latest Updated Date: 2025-02-26
  */
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:html/parser.dart';
@@ -16,13 +16,14 @@ import 'package:inha_notice/services/absolute_style_scraper/base_absolute_style_
 
 /// **WholeNoticeScraper**
 /// 이 클래스는 인하대학교 학사 공지사항을 크롤링하는 클래스입니다.
-class WholeNoticeScraper extends BaseAbsoluteStyleNoticeScraper {
+class WholeStyleNoticeScraper extends BaseAbsoluteStyleNoticeScraper {
   late final String baseUrl;
   late final String queryUrl;
+  late final String noticeType;
 
-  WholeNoticeScraper() {
-    baseUrl = dotenv.get('WHOLE_URL');
-    queryUrl = dotenv.get('WHOLE_QUERY_URL');
+  WholeStyleNoticeScraper(this.noticeType) {
+    baseUrl = dotenv.get('${noticeType}_URL');
+    queryUrl = dotenv.get('${noticeType}_QUERY_URL');
   }
 
   @override


### PR DESCRIPTION
## 📌 Related Issue
close #23
## 🚀 What's changed
- 인하대 공식 홈페이지에서 제공하는 URL로 변경
- 기존 탭 명칭 (장학, 채용)  -> (장학, 모집/채용)으로 변경

## 📢 Notes